### PR TITLE
Fix shebang so it uses bash from $PATH

### DIFF
--- a/repack.sh
+++ b/repack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # GLOBALS


### PR DESCRIPTION
This is required for NixOS for instance, as it doesn't have bash in /bin/bash